### PR TITLE
Change partialHtml to accept an extension function of TagConsumer instead of BODY

### DIFF
--- a/src/main/kotlin/no/mikill/kotlin_htmx/pages/HtmlElements.kt
+++ b/src/main/kotlin/no/mikill/kotlin_htmx/pages/HtmlElements.kt
@@ -45,20 +45,14 @@ object Styles {
 object HtmlRenderUtils {
     suspend fun ApplicationCall.respondHtmlFragment(
         status: HttpStatusCode = HttpStatusCode.OK,
-        block: BODY.() -> Unit,
+        block: TagConsumer<Appendable>.() -> Unit,
     ) {
         val text = partialHtml(block)
         respond(TextContent(text, ContentType.Text.Html.withCharset(Charsets.UTF_8), status))
     }
 
-    fun partialHtml(block: BODY.() -> Unit): String =
-        buildString {
-            appendHTML().filter { if (it.tagName in listOf("html", "body")) SKIP else PASS }.html {
-                body {
-                    block(this)
-                }
-            }
-        }
+    fun partialHtml(block: TagConsumer<Appendable>.() -> Unit): String =
+        buildString { appendHTML().block() }
 }
 
 object HtmlElements {


### PR DESCRIPTION
While working on a side project, I wanted to send just a tr (without a table) and since it needs to be in a table, I was not able to use partialHtml as is (I had implemented it in my project then found basically the same implementation here)

Also removed the filtering of body and head because maybe a user would want to include those specifically (although it wouldn't make much sense)